### PR TITLE
Add programme meeting and editing programme instructions

### DIFF
--- a/editing_the_programme.md
+++ b/editing_the_programme.md
@@ -1,0 +1,9 @@
+# Editing the programme
+
+1. When you've selected the sessions, on the [proposals page](https://spaconference.org/scripts/proposals.php), set the status of each proposal. (Open/Accepted/Rejected/Reserve/Pending). The only ones you *need* to set are those which are accepted.
+1. From `My SPA` page, follow the link "Edit the published programme". All the sessions that have been marked as "Accepted" in are available to add via drop-downs.
+1. Keynote details need to be added manually.
+1. The structure of the programme is currently set. If you want to make changes (e.g. finishing earlier or later, moving time/length of keynotes) please contact the website administrator.
+1. You can preview the programme as much as you like.
+1. When you publish, all session pages (e.g. https://spaconference.org/spa2017/sessions/session715.html) and session leader pages (e.g. https://spaconference.org/spa2017/people/eoinwoods.html) are published. It's worth checking through the user pages at this point as some submitters will have entered no details.
+3. To add the programme to the site menu, uncomment out the relevant lines in the [`_config.yml` in spa-website](https://github.com/spaconference/spa-website/blob/master/_config.yml).

--- a/editing_the_programme.md
+++ b/editing_the_programme.md
@@ -4,6 +4,7 @@
 1. From `My SPA` page, follow the link "Edit the published programme". All the sessions that have been marked as "Accepted" in are available to add via drop-downs.
 1. Keynote details need to be added manually.
 1. The structure of the programme is currently set. If you want to make changes (e.g. finishing earlier or later, moving time/length of keynotes) please contact the website administrator.
+1. If you'd like to create four tracks, just schedule sesssions into Wilkes 4 and this will be done automatically.
 1. You can preview the programme as much as you like.
 1. When you publish, all session pages (e.g. https://spaconference.org/spa2017/sessions/session715.html) and session leader pages (e.g. https://spaconference.org/spa2017/people/eoinwoods.html) are published. It's worth checking through the user pages at this point as some submitters will have entered no details.
 3. To add the programme to the site menu, uncomment out the relevant lines in the [`_config.yml` in spa-website](https://github.com/spaconference/spa-website/blob/master/_config.yml).

--- a/programme_meeting.md
+++ b/programme_meeting.md
@@ -1,0 +1,9 @@
+# Running the programme meeting
+
+In your MySPA page, if you are an admin, there is a section called "Programme Creation".
+1. To get all reviews for the selection process, print out the PDF of all reviews. This includes a summary of all reviews and session details (not including presenters' names).
+1. Once you've done a first pass of selecting what sessions are in or out, check the names of the presenters to make sure that no presenter has too many sessions and it's not unbalanced in any other way: View presenters' names in PDF format.
+1. It is worth putting together a reserve list of the top sessions that didn't quite make it (~10 maybe), as some of the accepted speakers will no longer be able to give their sessions; especially if they have multiple sessions accepted.
+1. As soon as the programme meeting is finished, email all the accepted speakers and give them a deadline to confirm attendance. We can't publish the programme until the speakers have accepted. You should ask them to update their sessions and user pages at this point, as what they've entered will be published.
+1. You should also email the rejected presenters.
+1. It is also worth emailing the reserve list to let them know they are in reserve and to give them a date by which we will let them know if they are in or out.

--- a/programme_meeting.md
+++ b/programme_meeting.md
@@ -1,10 +1,16 @@
 # Running the programme meeting
 
-In your MySPA page, if you are an admin, there is a section called "Programme Creation".
+## In your MySPA page, if you are an admin, there is a section called "Programme Creation".
+
 1. To get all reviews for the selection process, print out the PDF of all reviews. This includes a summary of all reviews and session details (not including presenters' names).
+1. The programme meeting is for the chairs to shape the conference. The reviews are a useful guide but you should definitely also consider sessions that may not have received all top scores but people in the meeting think will add value.
 1. Once you've done a first pass of selecting what sessions are in or out, check the names of the presenters to make sure that no presenter has too many sessions and it's not unbalanced in any other way: View presenters' names in PDF format.
 1. For scheduling purposes it's worth knowing that Wilkes 1, 2 and 3 each have a capacity of about 45. If you want to create a fourth track, you can split Wilkes 3 into two, but bear in mind that when Wilkes 3 and Wilkes 4 are both in operation they will each have a capacity of about 25.
 1. Put together a reserve list of the top sessions that didn't quite make it (~10 maybe), as some of the accepted speakers will no longer be able to give their sessions; especially if they have multiple sessions accepted.
+1. If you can come up with a suggestion of who would be good to shepherd each session in the programme meeting, that will save time later.
+
+## After the programme meeting
+
 1. As soon as the programme meeting is finished, email all the accepted speakers and give them a deadline to confirm attendance. We can't publish the programme until the speakers have accepted. You should ask them to update their sessions and user pages at this point, as what they've entered will be published.
 1. You should also email the rejected presenters.
 1. It is also worth emailing the reserve list to let them know they are in reserve and to give them a date by which we will let them know if they are in or out.

--- a/programme_meeting.md
+++ b/programme_meeting.md
@@ -4,7 +4,7 @@ In your MySPA page, if you are an admin, there is a section called "Programme Cr
 1. To get all reviews for the selection process, print out the PDF of all reviews. This includes a summary of all reviews and session details (not including presenters' names).
 1. Once you've done a first pass of selecting what sessions are in or out, check the names of the presenters to make sure that no presenter has too many sessions and it's not unbalanced in any other way: View presenters' names in PDF format.
 1. For scheduling purposes it's worth knowing that Wilkes 1, 2 and 3 each have a capacity of about 45. If you want to create a fourth track, you can split Wilkes 3 into two, but bear in mind that when Wilkes 3 and Wilkes 4 are both in operation they will each have a capacity of about 25.
-1. It is worth putting together a reserve list of the top sessions that didn't quite make it (~10 maybe), as some of the accepted speakers will no longer be able to give their sessions; especially if they have multiple sessions accepted.
+1. Put together a reserve list of the top sessions that didn't quite make it (~10 maybe), as some of the accepted speakers will no longer be able to give their sessions; especially if they have multiple sessions accepted.
 1. As soon as the programme meeting is finished, email all the accepted speakers and give them a deadline to confirm attendance. We can't publish the programme until the speakers have accepted. You should ask them to update their sessions and user pages at this point, as what they've entered will be published.
 1. You should also email the rejected presenters.
 1. It is also worth emailing the reserve list to let them know they are in reserve and to give them a date by which we will let them know if they are in or out.

--- a/programme_meeting.md
+++ b/programme_meeting.md
@@ -14,3 +14,4 @@
 1. As soon as the programme meeting is finished, email all the accepted speakers and give them a deadline to confirm attendance. We can't publish the programme until the speakers have accepted. You should ask them to update their sessions and user pages at this point, as what they've entered will be published.
 1. You should also email the rejected presenters.
 1. It is also worth emailing the reserve list to let them know they are in reserve and to give them a date by which we will let them know if they are in or out.
+1. You can [edit the programme](/editing_the_programme.md) straight away and save it in draft, and publish it when all sessions are confirmed.

--- a/programme_meeting.md
+++ b/programme_meeting.md
@@ -3,6 +3,7 @@
 In your MySPA page, if you are an admin, there is a section called "Programme Creation".
 1. To get all reviews for the selection process, print out the PDF of all reviews. This includes a summary of all reviews and session details (not including presenters' names).
 1. Once you've done a first pass of selecting what sessions are in or out, check the names of the presenters to make sure that no presenter has too many sessions and it's not unbalanced in any other way: View presenters' names in PDF format.
+1. For scheduling purposes it's worth knowing that Wilkes 1, 2 and 3 each have a capacity of about 45. If you want to create a fourth track, you can split Wilkes 3 into two, but bear in mind that when Wilkes 3 and Wilkes 4 are both in operation they will each have a capacity of about 25.
 1. It is worth putting together a reserve list of the top sessions that didn't quite make it (~10 maybe), as some of the accepted speakers will no longer be able to give their sessions; especially if they have multiple sessions accepted.
 1. As soon as the programme meeting is finished, email all the accepted speakers and give them a deadline to confirm attendance. We can't publish the programme until the speakers have accepted. You should ask them to update their sessions and user pages at this point, as what they've entered will be published.
 1. You should also email the rejected presenters.


### PR DESCRIPTION
Previously, these were stored elsewhere and I would email programme chairs before the meeting.

However, we now have the SPA handbook! So I've updated them and added them here.